### PR TITLE
Disable settings files for setup

### DIFF
--- a/recovery
+++ b/recovery
@@ -5,6 +5,9 @@ INSTDIR="$(dirname $0)"
 if systemctl --no-pager >/dev/null; then
 	noprep=nnn
 	chrootcmd="systemd-nspawn --settings=false -D$INSTDIR"
+	if test -d /usr/portage && test ! -d $INSTDIR/usr/portage; then
+		chrootcmd="$chrootcmd --bind=/usr/portage"
+	fi
 else
 	chroot=$(which chroot)
 	chrootcmd="env -i TERM=$TERM HOME=$HOME SHELL=/bin/bash $chroot $INSTDIR"

--- a/recovery
+++ b/recovery
@@ -5,7 +5,7 @@ INSTDIR="$(dirname $0)"
 if systemctl --no-pager >/dev/null; then
 	noprep=nnn
 	chrootcmd="systemd-nspawn --settings=false -D$INSTDIR"
-	if test -d /usr/portage/metadata/timestamp && test ! -d $INSTDIR/usr/portage/metadata/timestamp; then
+	if test -f /usr/portage/metadata/timestamp && test ! -f $INSTDIR/usr/portage/metadata/timestamp; then
 		chrootcmd="$chrootcmd --bind=/usr/portage"
 	fi
 else

--- a/recovery
+++ b/recovery
@@ -5,7 +5,7 @@ INSTDIR="$(dirname $0)"
 if systemctl --no-pager >/dev/null; then
 	noprep=nnn
 	chrootcmd="systemd-nspawn --settings=false -D$INSTDIR"
-	if test -d /usr/portage && test ! -d $INSTDIR/usr/portage; then
+	if test -d /usr/portage/metadata/timestamp && test ! -d $INSTDIR/usr/portage/metadata/timestamp; then
 		chrootcmd="$chrootcmd --bind=/usr/portage"
 	fi
 else

--- a/recovery
+++ b/recovery
@@ -4,7 +4,7 @@ INSTDIR="$(dirname $0)"
 
 if systemctl --no-pager >/dev/null; then
 	noprep=nnn
-	chrootcmd="systemd-nspawn -D$INSTDIR"
+	chrootcmd="systemd-nspawn --settings=false -D$INSTDIR"
 else
 	chroot=$(which chroot)
 	chrootcmd="env -i TERM=$TERM HOME=$HOME SHELL=/bin/bash $chroot $INSTDIR"


### PR DESCRIPTION
Placing a settings file for gshis.nspawn is really handy, but it can break the networking configuration when setting up the system.

Ignore the settings file when running under nspawn.
