### PR TITLE
Add GRUB supported platforms

### DIFF
--- a/etc/make.conf
+++ b/etc/make.conf
@@ -23,3 +23,4 @@ INPUT_DEVICES="$INPUT_MODULES evdev keyboard joystick mouse synaptics wacom"
 VIDEO_CARDS="intel nouveau radeon qxl vesa virtualbox"
 
 DRACUT_MODULES="$DRACUT_MODULES caps syslog"
+GRUB_PLATFORMS="pc efi-64"


### PR DESCRIPTION
When installing to bare-metal, bios (a.k.a. "pc") has been the supported platform.

Explicitly add the pc platform, plus efi-64 for testing #1.
