### PR TITLE
Add boot support to systemd

### DIFF
--- a/etc/portage/package.use/sys-apps
+++ b/etc/portage/package.use/sys-apps
@@ -1,3 +1,3 @@
 sys-apps/systemd curl importd gcrypt lzma
-sys-apps/systemd nat
+sys-apps/systemd nat gnuefi
 =sys-apps/util-linux-2.27.1 -systemd


### PR DESCRIPTION
bootctl requires /boot to be the EFI system partition (i.e. fat32)
