### PR TITLE
Next features

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ or an existing Linux distribution.
 7. Run the setup script under chroot  
 > \# /mnt/gentoo/recovery setup
 
-  * If you need to install kernel sources, use the '-g gentoo-sources' flag
+  * If you need to install kernel sources, use the '-g gentoo-sources' flag after adding 'freedist' to your licences:
+  * ```# tee -a /mnt/gentoo/etc/portage/make.conf<<<'ACCEPT_LICENSE="$ACCEPT_LICENSE freedist"'```
+  * ```# /mnt/gentoo/recovery setup -g gentoo-sources```
 8. Wait; and verify the installation
   * Build a kernel and prepare a bootloader
 9. Reboot!

--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ or an existing Linux distribution.
   installation environment)  
 > \# /mnt/gentoo/recovery prepare
 
-6. Setup a portage tree
-  * sync, or download a snapshot
-> \# /mnt/gentoo/recovery sync
+6. Setup a portage tree  
+> \# /mnt/gentoo/recovery web-sync
 
+  * if the stage has rsync, you can `sync`. If you don't have `emerge-webrsync`, the scripts
+    download a portage snapshot
 7. Run the setup script under chroot  
 > \# /mnt/gentoo/recovery setup
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,29 @@
 # Gentoo Self-Hosting Installation Scripts
 
-[Source](https://github.com/theappleman/gios4)
+[Source](https://github.com/theappleman/gshis)
 
 This is not an overlay in the normal portage sense.
 Nor is it a complete stage4.
 
-[This](https://github.com/theappleman/gios4/archive/master.tar.gz)
+[This](https://github.com/theappleman/gshis/archive/master.tar.gz)
 is a tarball that is unpacked over
 a stage3, and with the included scripts can setup gentoo in under 5 hours.
 
 ## Documentation
-* [Quick start](https://applehq.eu/projects/gentoo-ios4)
+* [Quick start](https://applehq.eu/projects/gshis)
 
 ## Downloads
 Clean tarballs that try to match the latest branches. To create your own,
 see _git-archive(1)_:
 
-* [master](https://github.com/theappleman/gios4/archive/master.tar.gz)
-* [master](https://github.com/theappleman/gios4/archive/next.tar.gz)
+* [master](https://github.com/theappleman/gshis/archive/master.tar.gz)
+* [next](https://github.com/theappleman/gshis/archive/next.tar.gz)
 
 ## Initial setup
 0. Boot into your installation environment; be that live media (e.g. CD, USB)
 or an existing Linux distribution.
   * Recommended: [System Rescue CD](http:sysresccd.org)
-1. Partition and format your drives
+1. (GPT/BIOS) Partition and format your drives
 > \# sgdisk -o -a 2 -n 1:34:2047 -t 1:ef02 -c 1:bios-boot -a 2048 \  
 > 	-n 2:2048:64M -t 2:8300 -c 2:boot \  
 > 	-n 3:64M:512M -t 3:8200 -c 3:swap \  
@@ -32,25 +32,38 @@ or an existing Linux distribution.
 > \# mke2fs -Tsmall /dev/sda2  
 > \# mkswap /dev/sda3; swapon /dev/sda3  
 > \# mkfs.btrfs /dev/sda4  
-> \# mount /dev/sda4 /mnt/gentoo
+> \# mount /dev/sda4 /mnt/gentoo  
 > \# mount /dev/sda2 /mnt/gentoo/boot
 
-2. Unpack the installation script tarball
-3. Download a stage3 tarball  
+2. (GPT/UEFI) Partition and format your drives
+> \# sgdisk -o -n 1:2048:512M -t 1:ef00 -c 1:system \  
+> 	-n 2:512M:1024M -t 2:8200 -c 2:swap \  
+> 	-N 3 -t 3:8300 -c 3:root \  
+> 	-G /dev/sda  
+> \# mkfs.vfat -F32 /dev/sda1  
+> \# mkswap /dev/sda2; swapon /dev/sda2  
+> \# mkfs.btrfs /dev/sda3  
+> \# mount /dev/sda3 /mnt/gentoo  
+> \# mkdir -p /mnt/gentoo/boot/EFI  
+> \# mount /dev/sda1 /mnt/gentoo/boot/EFI
+
+3. Unpack the installation script tarball
+4. Download a stage3 tarball  
 > \# /mnt/gentoo/recovery unpack
 
-4. Run the recovery script (you must do this every time you boot into your
+5. Run the recovery script (you must do this every time you boot into your
   installation environment)  
 > \# /mnt/gentoo/recovery prepare
 
-5. Setup a portage tree
+6. Setup a portage tree
   * sync, or download a snapshot
 > \# /mnt/gentoo/recovery sync
 
-6. Run the setup script under chroot  
+7. Run the setup script under chroot  
 > \# /mnt/gentoo/recovery setup
 
-  * Answer easy questions
-7. Wait; and verify the installation
-8. Reboot!
+  * If you need to install kernel sources, use the '-g gentoo-sources' flag
+8. Wait; and verify the installation
+  * Build a kernel and prepare a bootloader
+9. Reboot!
 

--- a/etc/sysctl.d/ipv6.conf
+++ b/etc/sysctl.d/ipv6.conf
@@ -1,2 +1,3 @@
 net.ipv6.conf.all.use_tempaddr = 2
 net.ipv6.conf.default.use_tempaddr = 2
+net.ipv6.bindv6only=1

--- a/recovery
+++ b/recovery
@@ -125,8 +125,8 @@ elif test x"$1" = "xsystemd"; then
 		emerge -qC sys-fs/udev virtual/udev || true
 	fi
 	
-	systemdver=$(qatom /var/db/pkg/sys-apps/systemd* | awk '$1=="sys-apps"&&$2=="systemd"{print$3}')
-	if test x"$systemdver" != "x" || test "$systemdver" -lt 228; then
+	systemdver=\$(qatom /var/db/pkg/sys-apps/systemd* | awk '\$1=="sys-apps"&&\$2=="systemd"{print\$3}')
+	if test x"\$systemdver" != "x" || test "\$systemdver" -lt 228; then
 		echo "WARNING: systemd not installed or version too low. Updating..." >&2
 		emerge -q1u '>=systemd-228'
 	fi

--- a/recovery
+++ b/recovery
@@ -2,13 +2,14 @@
 
 INSTDIR="$(dirname $0)"
 
-if systemctl --no-pager >/dev/null; then
+if test x"$1" != "x--chroot" && systemctl --no-pager >/dev/null; then
 	noprep=nnn
 	chrootcmd="systemd-nspawn --settings=false -D$INSTDIR"
 	if test -f /usr/portage/metadata/timestamp && test ! -f $INSTDIR/usr/portage/metadata/timestamp; then
 		chrootcmd="$chrootcmd --bind=/usr/portage"
 	fi
 else
+	test x"$1" = "x--chroot" && shift
 	chroot=$(which chroot)
 	chrootcmd="env -i TERM=$TERM HOME=$HOME SHELL=/bin/bash $chroot $INSTDIR"
 fi

--- a/recovery
+++ b/recovery
@@ -28,7 +28,7 @@ elif test x"$1" = "xsetup"; then
 elif test x"$1" = "xfetch" || test x"$1" = "xunpack"; then
 	pushd "$INSTDIR"
 	arch=$(uname -m | sed 's/x86_/amd/')
-	getpath=$(wget -q -O- http://${2:-distfiles.gentoo.org}/releases/$arch/autobuilds/latest-stage3-amd64.txt | awk 'NR==3{print$1}')
+	getpath=$(wget -q -O- http://${2:-distfiles.gentoo.org}/releases/$arch/autobuilds/latest-stage3-amd64-systemd.txt | awk 'NR==3{print$1}')
 	basepath=$(basename $getpath)
 	wget -c http://${2:-distfiles.gentoo.org}/releases/$arch/autobuilds/$getpath
 	test x"$1" = "xunpack" && $PV $basepath | tar xkjp -C $INSTDIR

--- a/recovery
+++ b/recovery
@@ -120,8 +120,16 @@ elif test x"$1" = "xsystemd"; then
 	fi
 	
 	# Remove udev in favour of systemd
-	emerge -qC sys-fs/udev virtual/udev || true
-	emerge -q1u systemd
+	if qatom /var/db/pkg/sys-fs/udev* | cut -d' ' -f2 | grep '^udev$'; then
+		echo "WARNING: udev installed. Removing..." >&2
+		emerge -qC sys-fs/udev virtual/udev || true
+	fi
+	
+	systemdver=$(qatom /var/db/pkg/sys-apps/systemd* | awk '$1=="sys-apps"&&$2=="systemd"{print$3}')
+	if test x"$systemdver" != "x" || test "$systemdver" -lt 228; then
+		echo "WARNING: systemd not installed or version too low. Updating..." >&2
+		emerge -q1u '>=systemd-228'
+	fi
 	sed -i -e '/^hosts/s/files dns/files mymachines resolve dns/' /etc/nsswitch.conf
 	sed -i -e '/util-linux/d' /etc/portage/package.use/sys-apps
 	rm /etc/resolv.conf; ln -s /run/systemd/resolve/resolv.conf /etc/resolv.conf

--- a/setup
+++ b/setup
@@ -1,7 +1,6 @@
 #!/bin/sh
 
 set -e
-extraprogs="grub:2"
 
 extraconfigs="
 NETFILTER_XT_MATCH_RECENT
@@ -46,6 +45,11 @@ env-update >/dev/null && source /etc/profile
 
 while test "${#@}" -gt 0; do
 	case "$1" in
+	# Setup grub in bios mode
+	-b)
+		extraprogs="$extraprogs grub:2"
+		bios="true"
+		;;
 	# Run genkernel during the build
 	-g)	run_genkernel="true"
 		memtot=$(awk '/MemTotal/{print$2}' /proc/meminfo)
@@ -195,27 +199,31 @@ if egrep -q 'sys-devel/gcc' /var/log/emerge.log; then
 	emerge -1q libtool
 fi
 
-cat >>/etc/fstab <<EOF
-$(get_uuid $(grub-probe -t device / | sed q) /) noatime 1 1
-EOF
+if test x"$bios" = "xtrue"; then
+	if mountpoint -q /boot; then
+		bootpart="$(grub-probe -t device /boot | sed q)"
+		test  "$bootpart" = "/dev/*" && cat >>/etc/fstab <<-EOF
+		$(get_uuid $bootpart /boot) noatime,noauto 1 2
+		EOF
 
-if mountpoint -q /boot; then
-	bootpart="$(grub-probe -t device /boot | sed q)"
-	test  "$bootpart" = "/dev/*" && cat >>/etc/fstab <<-EOF
-	$(get_uuid $bootpart /boot) noatime,noauto 1 2
+		# This produces output like:
+		#  (hostdisk//dev/sda,gpt3)
+		grub-probe -t drive /boot | sed 's://:/:' | egrep -o '/([^,]+)' | \
+			while read bootdev; do
+				test -b "$bootdev" && aac="$aac grub-install $bootdev;"
+			done
+	else
+		grub-probe -t drive / | sed 's://:/:' | egrep -o '/([^,]+)' | \
+			while read bootdev; do
+				test -b "$bootdev" && aac="$aac grub-install $bootdev;"
+			done
+	fi
+
+	rootpart=$(grub-probe -t device / | sed q)
+	test x"$rootpart" != "x" && uuid=$(get_uuid $rootpart /)
+	test x"$uuid" != "x" && cat >>/etc/fstab<<-EOF
+	$uuid noatime 1 1
 	EOF
-
-	# This produces output like:
-	#  (hostdisk//dev/sda,gpt3)
-	grub-probe -t drive /boot | sed 's://:/:' | egrep -o '/([^,]+)' | \
-		while read bootdev; do
-			test -b "$bootdev" && aac="$aac grub-install $bootdev;"
-		done
-else
-	grub-probe -t drive / | sed 's://:/:' | egrep -o '/([^,]+)' | \
-		while read bootdev; do
-			test -b "$bootdev" && aac="$aac grub-install $bootdev;"
-		done
 fi
 
 test "$aac" = "*grub-install*" && aac="$aac grub-mkconfig -o /boot/grub/grub.cfg;"

--- a/setup
+++ b/setup
@@ -228,6 +228,9 @@ if test x"$bios" = "xtrue"; then
 			aac="$aac grub-mkconfig -o /boot/grub/grub.cfg;"
 			;;
 	esac
+
+	egrep -q '^[^#]*GRUB_CMDLINE_LINUX=' /etc/default/grub || \
+		sed -i -e '/# GRUB_CMDLINE_LINUX="init=\/usr\/lib\/systemd\/systemd"/s/^# //' /etc/default/grub
 fi
 
 if test x"$run_genkernel" = "xtrue"; then
@@ -239,9 +242,6 @@ if test x"$run_genkernel" = "xtrue"; then
 
 	/usr/bin/genkernel $gkopts all
 fi
-
-egrep -q '^[^#]*GRUB_CMDLINE_LINUX=' /etc/default/grub || \
-	sed -i -e '/# GRUB_CMDLINE_LINUX="init=\/usr\/lib\/systemd\/systemd"/s/^# //' /etc/default/grub
 
 eselect news read
 

--- a/setup
+++ b/setup
@@ -51,6 +51,13 @@ while test "${#@}" -gt 0; do
 	-b)
 		extraprogs="$extraprogs grub:2"
 		bios="true"
+		if ! egrep -q ' /boot .*[ ,]ro[ ,]' /proc/mounts; then
+			echo "" >&2
+			echo "WARNING: Detected /boot mounted as read-only." >&2
+			echo "WARNING: Remounting as read-write..." >&2
+			echo "" >&2
+			remount=true
+		fi
 		;;
 	# Run genkernel during the build
 	-g)	run_genkernel="true"
@@ -185,8 +192,16 @@ cmp -s /etc/localtime /usr/share/zoneinfo/Factory && \
 	emerge -1q --config timezone-data
 
 # Remove udev in favour of systemd
-emerge -qC sys-fs/udev virtual/udev || true
-emerge -q1u systemd
+if qatom /var/db/pkg/sys-fs/udev* | cut -d' ' -f2 | grep '^udev$'; then
+	echo "WARNING: udev installed. Removing..." >&2
+	emerge -qC sys-fs/udev virtual/udev || true
+fi
+
+systemdver=$(qatom /var/db/pkg/sys-apps/systemd* | awk '$1=="sys-apps"&&$2=="systemd"{print$3}')
+if test x"$systemdver" != "x" || test "$systemdver" -lt 228; then
+	echo "WARNING: systemd not installed or version too low. Updating..." >&2
+	emerge -q1u '>=systemd-228'
+fi
 
 emerge -qu $fsprogs $extraprogs
 
@@ -223,6 +238,8 @@ if test x"$bios" = "xtrue"; then
 	test x"$uuid" != "x" && cat >>/etc/fstab<<-EOF
 	$uuid noatime 1 1
 	EOF
+
+	test x"$remount" = "xtrue" && mount -o rw,remount /boot
 
 	case "$aac" in
 		*grub-install*)

--- a/setup
+++ b/setup
@@ -3,6 +3,10 @@
 set -e
 extraprogs="grub:2"
 
+extraconfigs="
+NETFILTER_XT_MATCH_RECENT
+"
+
 arch=$(uname -m | sed -e 's/x86_/amd/;s/i6/x/')
 
 get_uuid() {
@@ -130,9 +134,10 @@ for i in $(get_fstype); do
 			;;
 	btrfs)	fsprogs="$fsprogs btrfs-progs"
 		dracutopts="$dracutopts btrfs"
-		# In addition to adding btrfs RAID to initramfs, pop open
-		# the config menu to add btrfs to the kernel
-		gkopts="$gkopts --btrfs --nconfig"
+		# In addition to adding btrfs RAID to initramfs,
+		# add btrfs support to the kernel
+		gkopts="$gkopts --btrfs"
+		extraconfigs="$extraconfigs BTRFS_FS"
 		# as part of this overlay, btrfs-progs is unmasked
 		;;
 	xfs)	fsprogs="$fsprogs xfsprogs"
@@ -215,7 +220,15 @@ fi
 
 test "$aac" = "*grub-install*" && aac="$aac grub-mkconfig -o /boot/grub/grub.cfg;"
 
-test x"$run_genkernel" = "xtrue" && /usr/bin/genkernel $gkopts all
+if test x"$run_genkernel" = "xtrue"; then
+	for OPT in $extraconfigs; do
+		/usr/src/linux/scripts/config \
+			--file /usr/share/genkernel/arch/$(uname -m | sed -e 's/i6/x/')/kernel-config \
+			-e $OPT
+	done
+
+	/usr/bin/genkernel $gkopts all
+fi
 
 egrep -q '^[^#]*GRUB_CMDLINE_LINUX=' /etc/default/grub || \
 	sed -i -e '/# GRUB_CMDLINE_LINUX="init=\/usr\/lib\/systemd\/systemd"/s/^# //' /etc/default/grub

--- a/setup
+++ b/setup
@@ -163,7 +163,7 @@ test x"$bec" = "x" || sh -c "$bec"
 emerge -q1u portage
 
 cmp -s /etc/localtime /usr/share/zoneinfo/Factory && \
-	emerge -1q timezone-data
+	emerge -1q --config timezone-data
 
 # Remove udev in favour of systemd
 emerge -qC sys-fs/udev virtual/udev || true

--- a/setup
+++ b/setup
@@ -4,6 +4,7 @@ set -e
 
 extraconfigs="
 NETFILTER_XT_MATCH_RECENT
+EFI_STUB
 "
 
 arch=$(uname -m | sed -e 's/x86_/amd/;s/i6/x/')

--- a/setup
+++ b/setup
@@ -222,4 +222,6 @@ egrep -q '^[^#]*GRUB_CMDLINE_LINUX=' /etc/default/grub || \
 
 eselect news read
 
+test -f /etc/machine-id || systemd-machine-id-setup
+
 test x"$aac" = "x" || sh -c "$aac"

--- a/setup
+++ b/setup
@@ -202,6 +202,7 @@ fi
 
 if test x"$bios" = "xtrue"; then
 	if mountpoint -q /boot; then
+		bootpath=/boot
 		bootpart="$(grub-probe -t device /boot | sed q)"
 		test  "$bootpart" = "/dev/*" && cat >>/etc/fstab <<-EOF
 		$(get_uuid $bootpart /boot) noatime,noauto 1 2
@@ -209,16 +210,12 @@ if test x"$bios" = "xtrue"; then
 
 		# This produces output like:
 		#  (hostdisk//dev/sda,gpt3)
-		grub-probe -t drive /boot | sed 's://:/:' | egrep -o '/([^,]+)' | \
-			while read bootdev; do
-				test -b "$bootdev" && aac="$aac grub-install $bootdev;"
-			done
+		bootdev=$(grub-probe -t drive /boot | sed 's://:/:' | egrep -o '/([^,]+)')
 	else
-		grub-probe -t drive / | sed 's://:/:' | egrep -o '/([^,]+)' | \
-			while read bootdev; do
-				test -b "$bootdev" && aac="$aac grub-install $bootdev;"
-			done
+		bootpath=/
 	fi
+	bootdev=$(grub-probe -t drive $bootpath | sed 's://:/:' | egrep -o '/([^,]+)')
+	test -b "$bootdev" && aac="$aac grub-install $bootdev;"
 
 	rootpart=$(grub-probe -t device / | sed q)
 	test x"$rootpart" != "x" && uuid=$(get_uuid $rootpart /)

--- a/setup
+++ b/setup
@@ -191,29 +191,29 @@ if egrep -q 'sys-devel/gcc' /var/log/emerge.log; then
 fi
 
 cat >>/etc/fstab <<EOF
-$(get_uuid $(grub2-probe -t device / | sed q) /) noatime 1 1
+$(get_uuid $(grub-probe -t device / | sed q) /) noatime 1 1
 EOF
 
 if mountpoint -q /boot; then
-	bootpart="$(grub2-probe -t device /boot | sed q)"
+	bootpart="$(grub-probe -t device /boot | sed q)"
 	test  "$bootpart" = "/dev/*" && cat >>/etc/fstab <<-EOF
 	$(get_uuid $bootpart /boot) noatime,noauto 1 2
 	EOF
 
 	# This produces output like:
 	#  (hostdisk//dev/sda,gpt3)
-	grub2-probe -t drive /boot | sed 's://:/:' | egrep -o '/([^,]+)' | \
+	grub-probe -t drive /boot | sed 's://:/:' | egrep -o '/([^,]+)' | \
 		while read bootdev; do
-			test -b "$bootdev" && aac="$aac grub2-install $bootdev;"
+			test -b "$bootdev" && aac="$aac grub-install $bootdev;"
 		done
 else
-	grub2-probe -t drive / | sed 's://:/:' | egrep -o '/([^,]+)' | \
+	grub-probe -t drive / | sed 's://:/:' | egrep -o '/([^,]+)' | \
 		while read bootdev; do
-			test -b "$bootdev" && aac="$aac grub2-install $bootdev;"
+			test -b "$bootdev" && aac="$aac grub-install $bootdev;"
 		done
 fi
 
-test "$aac" = "*grub2-install*" && aac="$aac grub2-mkconfig -o /boot/grub/grub.cfg;"
+test "$aac" = "*grub-install*" && aac="$aac grub-mkconfig -o /boot/grub/grub.cfg;"
 
 test x"$run_genkernel" = "xtrue" && /usr/bin/genkernel $gkopts all
 

--- a/setup
+++ b/setup
@@ -46,11 +46,19 @@ while test "${#@}" -gt 0; do
 	-g)	run_genkernel="true"
 		memtot=$(awk '/MemTotal/{print$2}' /proc/meminfo)
 		swaptot=$(awk '/SwapTotal/{print$2}' /proc/meminfo)
-		if test $(( $memtot + $swaptot )) -gt 512808; then
-			extraprogs="$extraprogs genkernel-next"
-		else
+		extraprogs="$extraprogs genkernel-next"
+		if test $(( $memtot + $swaptot )) -lt 512808; then
 			# bug 554200
 			(echo Not enough RAM to compile boost for genkernel-next.>&2;)
+			(echo Adding make.conf flags to lower memory requirements.>&2;)
+			sed -i -e '/MAKEOPTS/s/^/#/' /etc/portage/make.conf
+			tee -a /etc/portage/make.conf <<<'MAKEOPTS="-j1"'
+			# very light optimisations
+			tee -a /etc/portage/make.conf <<<'CFLAGS="$CFLAGS --param ggc-min-expand=20 --param ggc-min-heapsize=32768"'
+			# medium optimisations
+			#tee -a /etc/portage/make.conf <<<'CFLAGS="$CFLAGS --param ggc-min-expand=10 --param ggc-min-heapsize=8192"'
+			# extreme optimisations
+			#tee -a /etc/portage/make.conf <<<'CFLAGS="$CFLAGS --param ggc-min-expand=0 --param ggc-min-heapsize=4096 -fno-inline"'
 		fi
 		;;
 	# Set profile to hardened

--- a/setup
+++ b/setup
@@ -51,7 +51,7 @@ while test "${#@}" -gt 0; do
 	-b)
 		extraprogs="$extraprogs grub:2"
 		bios="true"
-		if ! egrep -q ' /boot .*[ ,]ro[ ,]' /proc/mounts; then
+		if mountpoint -q /boot && ! egrep -q ' /boot .*[ ,]ro[ ,]' /proc/mounts; then
 			echo "" >&2
 			echo "WARNING: Detected /boot mounted as read-only." >&2
 			echo "WARNING: Remounting as read-write..." >&2

--- a/setup
+++ b/setup
@@ -5,6 +5,7 @@ extraprogs="grub:2"
 
 extraconfigs="
 NETFILTER_XT_MATCH_RECENT
+NETFILTER_XT_TARGET_LOG
 "
 
 arch=$(uname -m | sed -e 's/x86_/amd/;s/i6/x/')

--- a/setup
+++ b/setup
@@ -222,9 +222,13 @@ if test x"$bios" = "xtrue"; then
 	test x"$uuid" != "x" && cat >>/etc/fstab<<-EOF
 	$uuid noatime 1 1
 	EOF
-fi
 
-test "$aac" = "*grub-install*" && aac="$aac grub-mkconfig -o /boot/grub/grub.cfg;"
+	case "$aac" in
+		*grub-install*)
+			aac="$aac grub-mkconfig -o /boot/grub/grub.cfg;"
+			;;
+	esac
+fi
 
 if test x"$run_genkernel" = "xtrue"; then
 	for OPT in $extraconfigs; do

--- a/var/lib/ip6tables/rules-save
+++ b/var/lib/ip6tables/rules-save
@@ -1,6 +1,6 @@
 *filter
 :INPUT DROP [0:0]
-:FORWARD ACCEPT [0:0]
+:FORWARD DROP [0:0]
 :OUTPUT ACCEPT [0:0]
 :TCP - [0:0]
 :UDP - [0:0]

--- a/var/lib/ip6tables/rules-save
+++ b/var/lib/ip6tables/rules-save
@@ -7,15 +7,18 @@
 [0:0] -A INPUT -i lo -j ACCEPT
 [0:0] -A INPUT -m conntrack --ctstate INVALID -j DROP
 [0:0] -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-[0:0] -A OUTPUT -m conntrack --ctstate INVALID -j DROP
-[0:0] -A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-[0:0] -A OUTPUT -p ipv6-icmp -j ACCEPT
 [0:0] -A INPUT -p ipv6-icmp -j ACCEPT
 [0:0] -A INPUT -p udp -m conntrack --ctstate NEW -j UDP
 [0:0] -A INPUT -p tcp -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -m conntrack --ctstate NEW -j TCP
 [0:0] -A INPUT -p udp -j REJECT --reject-with icmp6-port-unreachable
 [0:0] -A INPUT -p tcp -j REJECT --reject-with tcp-reset
 [0:0] -A INPUT -j REJECT --reject-with icmp6-port-unreachable
+[0:0] -A OUTPUT -o lo -j ACCEPT
+[0:0] -A OUTPUT -m conntrack --ctstate INVALID -j DROP
+[0:0] -A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+[0:0] -A OUTPUT -p ipv6-icmp -j ACCEPT
+[0:0] -A OUTPUT -m conntrack --ctstate NEW -m limit --limit 2/min -j LOG --log-prefix "v6-out: "
+[0:0] -A FORWARD -m conntrack --ctstate NEW -m limit --limit 2/min -j LOG --log-prefix "v6-for: "
 [0:0] -A TCP -p tcp -m tcp --dport 22 -m recent --set --name ssh --rsource
 [0:0] -A TCP -p tcp -m tcp --dport 22 -m recent ! --rcheck --seconds 60 --hitcount 4 --name ssh --rsource -j ACCEPT
 COMMIT

--- a/var/lib/ip6tables/rules-save
+++ b/var/lib/ip6tables/rules-save
@@ -1,12 +1,14 @@
 *filter
 :INPUT DROP [0:0]
 :FORWARD DROP [0:0]
-:OUTPUT ACCEPT [0:0]
+:OUTPUT DROP [0:0]
 :TCP - [0:0]
 :UDP - [0:0]
 [0:0] -A INPUT -i lo -j ACCEPT
 [0:0] -A INPUT -m conntrack --ctstate INVALID -j DROP
 [0:0] -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+[0:0] -A OUTPUT -m conntrack --ctstate INVALID -j DROP
+[0:0] -A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 [0:0] -A INPUT -p ipv6-icmp -j ACCEPT
 [0:0] -A INPUT -p udp -m conntrack --ctstate NEW -j UDP
 [0:0] -A INPUT -p tcp -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -m conntrack --ctstate NEW -j TCP

--- a/var/lib/ip6tables/rules-save
+++ b/var/lib/ip6tables/rules-save
@@ -12,11 +12,14 @@
 [0:0] -A INPUT -p tcp -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -m conntrack --ctstate NEW -j TCP
 [0:0] -A INPUT -p udp -j REJECT --reject-with icmp6-port-unreachable
 [0:0] -A INPUT -p tcp -j REJECT --reject-with tcp-reset
+[0:0] -A INPUT -m conntrack --ctstate NEW -m limit --limit 2/min -j LOG --log-prefix "v6-in: "
 [0:0] -A INPUT -j REJECT --reject-with icmp6-port-unreachable
 [0:0] -A OUTPUT -o lo -j ACCEPT
 [0:0] -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 [0:0] -A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 [0:0] -A OUTPUT -p ipv6-icmp -j ACCEPT
+[0:0] -A OUTPUT -p udp --dport 53 -m limit --limit 1/sec -j ACCEPT
+[0:0] -A OUTPUT -p tcp -m multiport --dports 53,80,443 -m limit --limit 1/sec -j ACCEPT
 [0:0] -A OUTPUT -m conntrack --ctstate NEW -m limit --limit 2/min -j LOG --log-prefix "v6-out: "
 [0:0] -A FORWARD -m conntrack --ctstate NEW -m limit --limit 2/min -j LOG --log-prefix "v6-for: "
 [0:0] -A TCP -p tcp -m tcp --dport 22 -m recent --set --name ssh --rsource

--- a/var/lib/ip6tables/rules-save
+++ b/var/lib/ip6tables/rules-save
@@ -18,10 +18,12 @@
 [0:0] -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 [0:0] -A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 [0:0] -A OUTPUT -p ipv6-icmp -j ACCEPT
-[0:0] -A OUTPUT -p udp --dport 53 -m limit --limit 1/sec -j ACCEPT
-[0:0] -A OUTPUT -p tcp -m multiport --dports 53,80,443 -m limit --limit 1/sec -j ACCEPT
+[0:0] -A OUTPUT -p udp -m multiport --dports 53                  -m limit --limit 60/sec -j ACCEPT
+[0:0] -A OUTPUT -p tcp -m multiport --dports 21,22,53,80,443,873 -m limit --limit 60/sec -j ACCEPT
 [0:0] -A OUTPUT -m conntrack --ctstate NEW -m limit --limit 2/min -j LOG --log-prefix "v6-out: "
+[0:0] -A OUTPUT -j REJECT --reject-with icmp6-port-unreachable
 [0:0] -A FORWARD -m conntrack --ctstate NEW -m limit --limit 2/min -j LOG --log-prefix "v6-for: "
+[0:0] -A FORWARD -j REJECT --reject-with icmp6-port-unreachable
 [0:0] -A TCP -p tcp -m tcp --dport 22 -m recent --set --name ssh --rsource
 [0:0] -A TCP -p tcp -m tcp --dport 22 -m recent ! --rcheck --seconds 60 --hitcount 4 --name ssh --rsource -j ACCEPT
 COMMIT

--- a/var/lib/ip6tables/rules-save
+++ b/var/lib/ip6tables/rules-save
@@ -9,6 +9,7 @@
 [0:0] -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 [0:0] -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 [0:0] -A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+[0:0] -A OUTPUT -p ipv6-icmp -j ACCEPT
 [0:0] -A INPUT -p ipv6-icmp -j ACCEPT
 [0:0] -A INPUT -p udp -m conntrack --ctstate NEW -j UDP
 [0:0] -A INPUT -p tcp -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -m conntrack --ctstate NEW -j TCP

--- a/var/lib/iptables/rules-save
+++ b/var/lib/iptables/rules-save
@@ -1,6 +1,6 @@
 *filter
 :INPUT DROP [0:0]
-:FORWARD ACCEPT [0:0]
+:FORWARD DROP [0:0]
 :OUTPUT ACCEPT [0:0]
 :TCP - [0:0]
 :UDP - [0:0]

--- a/var/lib/iptables/rules-save
+++ b/var/lib/iptables/rules-save
@@ -13,8 +13,11 @@
 [0:0] -A INPUT -p udp -j REJECT --reject-with icmp-port-unreachable
 [0:0] -A INPUT -p tcp -j REJECT --reject-with tcp-reset
 [0:0] -A INPUT -j REJECT --reject-with icmp-proto-unreachable
+[0:0] -A OUTPUT -o lo -j ACCEPT
 [0:0] -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 [0:0] -A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+[0:0] -A OUTPUT -m conntrack --ctstate NEW -m limit --limit 2/min -j LOG --log-prefix "v4-out: "
+[0:0] -A FORWARD -m conntrack --ctstate NEW -m limit --limit 2/min -j LOG --log-prefix "v4-for: "
 [0:0] -A TCP -p tcp -m tcp --dport 22 -m recent --set --name ssh --rsource
 [0:0] -A TCP -p tcp -m tcp --dport 22 -m recent ! --rcheck --seconds 60 --hitcount 4 --name ssh --rsource -j ACCEPT
 COMMIT

--- a/var/lib/iptables/rules-save
+++ b/var/lib/iptables/rules-save
@@ -17,10 +17,12 @@
 [0:0] -A OUTPUT -o lo -j ACCEPT
 [0:0] -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 [0:0] -A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-[0:0] -A OUTPUT -p udp --dport 53 -m limit --limit 1/sec -j ACCEPT
-[0:0] -A OUTPUT -p tcp -m multiport --dports 53,80,443 -m limit --limit 1/sec -j ACCEPT
+[0:0] -A OUTPUT -p udp -m multiport --dports 53                  -m limit --limit 60/sec -j ACCEPT
+[0:0] -A OUTPUT -p tcp -m multiport --dports 21,22,53,80,443,873 -m limit --limit 60/sec -j ACCEPT
 [0:0] -A OUTPUT -m conntrack --ctstate NEW -m limit --limit 2/min -j LOG --log-prefix "v4-out: "
+[0:0] -A OUTPUT -j REJECT --reject-with icmp-proto-unreachable
 [0:0] -A FORWARD -m conntrack --ctstate NEW -m limit --limit 2/min -j LOG --log-prefix "v4-for: "
+[0:0] -A FORWARD -j REJECT --reject-with icmp-proto-unreachable
 [0:0] -A TCP -p tcp -m tcp --dport 22 -m recent --set --name ssh --rsource
 [0:0] -A TCP -p tcp -m tcp --dport 22 -m recent ! --rcheck --seconds 60 --hitcount 4 --name ssh --rsource -j ACCEPT
 COMMIT

--- a/var/lib/iptables/rules-save
+++ b/var/lib/iptables/rules-save
@@ -12,10 +12,13 @@
 [0:0] -A INPUT -p tcp -m tcp --tcp-flags FIN,SYN,RST,ACK SYN -m conntrack --ctstate NEW -j TCP
 [0:0] -A INPUT -p udp -j REJECT --reject-with icmp-port-unreachable
 [0:0] -A INPUT -p tcp -j REJECT --reject-with tcp-reset
+[0:0] -A INPUT -m conntrack --ctstate NEW -m limit --limit 2/min -j LOG --log-prefix "v4-in: "
 [0:0] -A INPUT -j REJECT --reject-with icmp-proto-unreachable
 [0:0] -A OUTPUT -o lo -j ACCEPT
 [0:0] -A OUTPUT -m conntrack --ctstate INVALID -j DROP
 [0:0] -A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+[0:0] -A OUTPUT -p udp --dport 53 -m limit --limit 1/sec -j ACCEPT
+[0:0] -A OUTPUT -p tcp -m multiport --dports 53,80,443 -m limit --limit 1/sec -j ACCEPT
 [0:0] -A OUTPUT -m conntrack --ctstate NEW -m limit --limit 2/min -j LOG --log-prefix "v4-out: "
 [0:0] -A FORWARD -m conntrack --ctstate NEW -m limit --limit 2/min -j LOG --log-prefix "v4-for: "
 [0:0] -A TCP -p tcp -m tcp --dport 22 -m recent --set --name ssh --rsource

--- a/var/lib/iptables/rules-save
+++ b/var/lib/iptables/rules-save
@@ -1,7 +1,7 @@
 *filter
 :INPUT DROP [0:0]
 :FORWARD DROP [0:0]
-:OUTPUT ACCEPT [0:0]
+:OUTPUT DROP [0:0]
 :TCP - [0:0]
 :UDP - [0:0]
 [0:0] -A INPUT -i lo -j ACCEPT
@@ -13,6 +13,8 @@
 [0:0] -A INPUT -p udp -j REJECT --reject-with icmp-port-unreachable
 [0:0] -A INPUT -p tcp -j REJECT --reject-with tcp-reset
 [0:0] -A INPUT -j REJECT --reject-with icmp-proto-unreachable
+[0:0] -A OUTPUT -m conntrack --ctstate INVALID -j DROP
+[0:0] -A OUTPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 [0:0] -A TCP -p tcp -m tcp --dport 22 -m recent --set --name ssh --rsource
 [0:0] -A TCP -p tcp -m tcp --dport 22 -m recent ! --rcheck --seconds 60 --hitcount 4 --name ssh --rsource -j ACCEPT
 COMMIT


### PR DESCRIPTION
- Updated documentation
- Tighten default firewall rules
- Allow forcing use of old-school chroot (manual workaround)
- Use upstream provided systemd stages (these do not come with systemd-228-r1 which we do want)
- Don't completely remerge timezone-data, just fix the timezone with --config
- Automatically set lower CFLAGS to help boost compile in low memory environments
